### PR TITLE
ネイティブ UIではなく、test explorer uiをデフォルトにする

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,7 @@
   "python.languageServer": "Pylance",
   "python.analysis.indexing": true,
   "python.testing.pytestArgs": ["tests"],
+  "testExplorer.useNativeTesting": false,
   "python.analysis.packageIndexDepths": [
     {
       "name": "",
@@ -155,24 +156,5 @@
   ],
   "errorLens.excludeBySource": ["cSpell"],
   "errorLens.gutterIconsEnabled": true,
-  "errorLens.gutterIconSet": "emoji",
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#05848b",
-    "activityBar.background": "#05848b",
-    "activityBar.foreground": "#e7e7e7",
-    "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#fb84f4",
-    "activityBarBadge.foreground": "#15202b",
-    "commandCenter.border": "#e7e7e799",
-    "sash.hoverBorder": "#05848b",
-    "statusBar.background": "#03555a",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#05848b",
-    "statusBarItem.remoteBackground": "#03555a",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#03555a",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#03555a99",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  }
+  "errorLens.gutterIconSet": "emoji"
 }


### PR DESCRIPTION
# セルフチェック

- [x] [PRガイドライン](https://github.com/tomo1227/python_template/blame/main/README.md#pull-request-%E3%82%AC%E3%82%A4%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3)を守っている
- [x] ローカルでビルド、テストが通っている
- [x] [styleguide | Style guides for Google-originated open-source projects](https://google.github.io/styleguide/pyguide.html)に沿って実装できている
- [x] ドキュメント化ができている

# 目的

# やったこと

# やらなかったこと

# 影響範囲

# 関連事項

# その他
